### PR TITLE
ENH: Add 'Inspirations' section to portfolio

### DIFF
--- a/index.html
+++ b/index.html
@@ -606,6 +606,69 @@
       </div>
     </div>
 
+    <!-- Inspirations Section -->
+    <div class="mb-5" id="inspirations-section">
+      <h2 class="section-title h3 text-white fw-semibold mb-4 position-relative d-inline-block">
+        <i class="bi bi-book-half me-3"></i>Inspirations
+      </h2>
+      <div class="row g-4">
+    <!-- Item 1: Technical Book -->
+    <div class="col-lg-4 col-md-6">
+      <div class="card h-100 border-0 shadow-lg bg-white bg-opacity-90 backdrop-blur rounded-3 transition-all">
+        <div class="card-body p-4 text-center d-flex flex-column">
+          <div class="mb-3">
+            <div class="mx-auto d-flex align-items-center justify-content-center text-white rounded-circle" style="width: 80px; height: 80px; background: var(--primary-gradient);">
+              <i class="bi bi-book h2 mb-0"></i>
+            </div>
+          </div>
+          <h5 class="card-title fw-semibold mb-2">Designing Data-Intensive Applications</h5>
+          <h6 class="text-muted small mb-3">By Martin Kleppmann</h6>
+          <p class="card-text text-muted mb-3 flex-grow-1">
+            A foundational read that clarified how distributed systems work at scale. Changed my perspective on system design.
+          </p>
+          <a href="#" class="btn btn-sm btn-outline-primary mt-auto" target="_blank">Learn More <i class="bi bi-box-arrow-up-right ms-1"></i></a>
+        </div>
+      </div>
+    </div>
+    <!-- Item 2: Non-Fiction Book -->
+    <div class="col-lg-4 col-md-6">
+      <div class="card h-100 border-0 shadow-lg bg-white bg-opacity-90 backdrop-blur rounded-3 transition-all">
+        <div class="card-body p-4 text-center d-flex flex-column">
+          <div class="mb-3">
+            <div class="mx-auto d-flex align-items-center justify-content-center text-white rounded-circle" style="width: 80px; height: 80px; background: var(--accent-gradient);">
+              <i class="bi bi-lightbulb h2 mb-0"></i>
+            </div>
+          </div>
+          <h5 class="card-title fw-semibold mb-2">Sapiens: A Brief History of Humankind</h5>
+          <h6 class="text-muted small mb-3">By Yuval Noah Harari</h6>
+          <p class="card-text text-muted mb-3 flex-grow-1">
+            Profound insights into our species' journey and the stories we tell. Truly thought-provoking.
+          </p>
+          <a href="#" class="btn btn-sm btn-outline-primary mt-auto" target="_blank">Learn More <i class="bi bi-box-arrow-up-right ms-1"></i></a>
+        </div>
+      </div>
+    </div>
+    <!-- Item 3: Podcast -->
+    <div class="col-lg-4 col-md-6">
+      <div class="card h-100 border-0 shadow-lg bg-white bg-opacity-90 backdrop-blur rounded-3 transition-all">
+        <div class="card-body p-4 text-center d-flex flex-column">
+          <div class="mb-3">
+            <div class="mx-auto d-flex align-items-center justify-content-center text-white rounded-circle" style="width: 80px; height: 80px; background: var(--secondary-gradient);">
+              <i class="bi bi-mic h2 mb-0"></i>
+            </div>
+          </div>
+          <h5 class="card-title fw-semibold mb-2">Lex Fridman Podcast</h5>
+          <h6 class="text-muted small mb-3">Hosted by Lex Fridman</h6>
+          <p class="card-text text-muted mb-3 flex-grow-1">
+            Deep dives into AI, science, and the human condition. Always sparks new ideas and perspectives.
+          </p>
+          <a href="#" class="btn btn-sm btn-outline-primary mt-auto" target="_blank">Listen Here <i class="bi bi-box-arrow-up-right ms-1"></i></a>
+        </div>
+      </div>
+    </div>
+      </div>
+    </div>
+
     <!-- Contact Section -->
     <div class="card text-center border-0 shadow-lg bg-white bg-opacity-90 backdrop-blur rounded-3">
       <div class="card-body py-5 px-4">


### PR DESCRIPTION
This commit introduces a new 'Inspirations' section to the personal portfolio website.

The section is designed to showcase books, podcasts, or other resources that have been influential, adding a personal yet professional touch to the portfolio. It aims to provide insight into intellectual influences without resembling a resume.

Key changes:
- Added HTML structure for the 'Inspirations' section in `index.html`, placed after 'Hobbies & Interests' and before 'Contact'.
- The section uses a card-based layout, consistent with other parts of the website, displaying 3 items per row on large screens.
- Leveraged existing CSS styles and Bootstrap classes to ensure visual consistency with the overall theme, requiring no new CSS rules.
- Populated the section with three placeholder items (2 books, 1 podcast) including titles, authors/hosts, brief personal notes, and placeholder links.
- Ensured responsive design using Bootstrap's grid system.
- Applied Bootstrap flex utilities to cards for consistent height and content alignment.